### PR TITLE
This should fix issue #3

### DIFF
--- a/main.m
+++ b/main.m
@@ -157,11 +157,12 @@ NSString* scriptableDateStringFromComponents(NSDateComponents* inComponents)
 		// It seems that apple script uses the localized date format to parse strings to date.
         // So using a fixed date format won't work for people that have different or custom date format
         // Here is some more info about this: http://www.jimmcgowan.net/Site/CocoaApplescriptUnicodeDateFormats.html
-        // There for we use localziedStringFromDate in order to produce a string accroding to the system locale.
+        // Therefor we use localziedStringFromDate in order to produce a string accroding to the system locale.
 		NSDate *targetDate = [gregorianCalendar() dateFromComponents:inComponents];
 		dateString = [NSDateFormatter localizedStringFromDate:targetDate
-                                                    dateStyle:NSDateFormatterMediumStyle
-                                                    timeStyle:NSDateFormatterShortStyle];
+                                                    dateStyle:NSDateFormatterFullStyle
+                                                    timeStyle:NSDateFormatterMediumStyle];
+        NSLog(@"dateString:%@", dateString);
 	}
 
 	return dateString;


### PR DESCRIPTION
Apple Script expects the date to follow the format set in the regional 
settings. 
Without this fix the app was crashing as described in issue #3
Change the code to use localizedStringFromDate fix the issue on my system
(I have locale set to a custom format).

I guess it will work for other locales too, but I haven't test it.
